### PR TITLE
Add auto-scroll to current time on My Schedule page

### DIFF
--- a/app.js
+++ b/app.js
@@ -384,7 +384,7 @@ function renderTimeline(performances) {
         }
 
         html += `
-            <div class="timeline-item">
+            <div class="timeline-item" data-timestamp="${perf.timestamp}">
                 <div class="timeline-card">
                     <div class="timeline-time">${perf.Time}</div>
                     <div class="timeline-artist">${perf.Artist}</div>
@@ -395,6 +395,46 @@ function renderTimeline(performances) {
     });
 
     container.innerHTML = html;
+
+    // Auto-scroll to current time
+    scrollToCurrentTime();
+}
+
+// Scroll to the current or next performance
+function scrollToCurrentTime() {
+    const now = Date.now();
+    const timelineItems = document.querySelectorAll('.timeline-item[data-timestamp]');
+
+    if (timelineItems.length === 0) return;
+
+    let targetItem = null;
+
+    // Find the first performance that hasn't ended yet (current or upcoming)
+    // Assume each performance is about 1 hour long
+    const performanceDuration = 60 * 60 * 1000; // 1 hour in milliseconds
+
+    for (let item of timelineItems) {
+        const timestamp = parseInt(item.dataset.timestamp);
+        const endTime = timestamp + performanceDuration;
+
+        // If performance hasn't ended yet, this is our target
+        if (endTime >= now) {
+            targetItem = item;
+            break;
+        }
+    }
+
+    // If no upcoming/current performance found, scroll to the last item
+    if (!targetItem && timelineItems.length > 0) {
+        targetItem = timelineItems[timelineItems.length - 1];
+    }
+
+    // Scroll the target item into view with smooth animation
+    if (targetItem) {
+        setTimeout(() => {
+            targetItem.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        }, 100);
+    }
 }
 
 // Utility


### PR DESCRIPTION
When the My Schedule page loads, it now automatically scrolls to show
the current or next upcoming performance. The scroll logic:
- Finds the first performance that hasn't ended yet (assuming 1 hour duration)
- If all performances are past, scrolls to the last item
- Uses smooth scrolling animation and centers the item in view

This improves the user experience by immediately showing relevant performances
when opening the schedule.